### PR TITLE
Fix splitscreen end of match name

### DIFF
--- a/Common/Scripts/Modes/TrackMania/TMSplitScreen_Competition.Script.txt
+++ b/Common/Scripts/Modes/TrackMania/TMSplitScreen_Competition.Script.txt
@@ -251,7 +251,7 @@ main()
 			
 			declare VictoryText = TextLib::Compose(_("$<%1$> wins the match!"), Scores[0].User.Name);
 			UILayerScores.ManialinkPage = GetFrameMapTimes();
-			UILayerWinner.ManialinkPage ^= 
+			UILayerWinner.ManialinkPage = 
 				"""<frame posn="0 60">
 				<quad  posn="0 3 -1"	sizen="130 14"	halign="center"	style="Bgs1InRace" substyle="BgTitle3"  />
 				<label posn="0 0"						halign="center" scale="2" text="{{{VictoryText}}}" />


### PR DESCRIPTION
UILayerWinner.ManialinkPage was concatenating so each time a match ended another frame with the most recent winner was added. This resulted in the end of match scene displaying all previous winners overlapping the current winner.

Reference of the bug:
https://forum.maniaplanet.com/viewtopic.php?f=470&t=22091#p182673
https://forum.maniaplanet.com/viewtopic.php?f=427&t=12535#p113598