### PR TITLE
Option to turn on/off match server reconnection.

### DIFF
--- a/Common/Scripts/Libs/Nadeo/MatchmakingLobby.Script.txt
+++ b/Common/Scripts/Libs/Nadeo/MatchmakingLobby.Script.txt
@@ -2,7 +2,7 @@
  *	Matchmaking lobby library
  */
 
-#Const Version		"2017-11-21"
+#Const Version		"2018-02-15"
 #Const ScriptName	"Libs/Nadeo/MatchmakingLobby.Script.txt"
 
 #Include "TextLib" as TL
@@ -61,6 +61,7 @@
 // ---------------------------------- //
 declare Boolean G_LibMMLobby_DisableUI;								///< Disable the lobby UI
 declare Boolean G_LibMMLobby_KickTimedOutPlayers;			///< Kick timed out players
+declare Boolean G_LibMMLobby_EnableMatchReconnect;		///< Send reconnecting players to match servers
 declare Integer G_LibMMLobby_StartTime;								///< Startime of the lobby
 declare Integer G_LibMMLobby_EndTime;									///< EndTime of the lobby
 declare Integer	G_LibMMLobby_Phase;										///< Current lobby phase : playing/matchmaking
@@ -201,6 +202,24 @@ Void KickTimedOutPlayers(Boolean _Kick) {
 	
 	declare netwrite Net_LibMMLobby_KickTimedOutPlayers for Teams[0] = False;
 	Net_LibMMLobby_KickTimedOutPlayers = G_LibMMLobby_KickTimedOutPlayers;
+}
+
+// ---------------------------------- //
+/** Reconnect players to match servers
+ *
+ *	@param	_Reconnect		Reconnect players to matches or not
+ */
+Void EnableMatchReconnect(Boolean _Reconnect) {
+	G_LibMMLobby_EnableMatchReconnect = _Reconnect;
+}
+
+// ---------------------------------- //
+/** Check if the match reconnect is enabled in the lobby
+ *
+ *	@return				True if the match reconnect is enabled, False otherwise
+ */
+Boolean MatchReconnectEnabled() {
+	return G_LibMMLobby_EnableMatchReconnect;
 }
 
 // ---------------------------------- //
@@ -1666,7 +1685,7 @@ Void SetupPlayer(Text _PlayerXml) {
 								Lobby_LastPenaltyMatchId = MatchId;
 							}
 						} else {
-							if (MatchId != Lobby_LastPenaltyMatchId && GetPlayerPenalty(Player.User) < 0 && MatchServerLogin != "") {
+							if (G_LibMMLobby_EnableMatchReconnect && MatchId != Lobby_LastPenaltyMatchId && GetPlayerPenalty(Player.User) < 0 && MatchServerLogin != "") {
 								declare Lobby_ReconnectToServer for Player = "";
 								Lobby_ReconnectToServer = MatchServerLogin;
 							}
@@ -2979,7 +2998,7 @@ Boolean MM_PlayLoop() {
 		
 		// ---------------------------------- //
 		// Try to reconnect to the match server after a leave
-		ReconnectToServer(Player);
+		if (G_LibMMLobby_EnableMatchReconnect) ReconnectToServer(Player);
 	}
 	
 	return NeedAlliesUpdate;
@@ -5576,6 +5595,7 @@ Void Unload() {
 	
 	G_LibMMLobby_DisableUI = False;
 	G_LibMMLobby_KickTimedOutPlayers = False;
+	G_LibMMLobby_EnableMatchReconnect = True;
 	G_LibMMLobby_StartTime = -1;
 	G_LibMMLobby_EndTime = -1;
 	G_LibMMLobby_Phase = C_Lobby_Playing;

--- a/Common/Scripts/Modes/ModeMatchmaking2.Script.txt
+++ b/Common/Scripts/Modes/ModeMatchmaking2.Script.txt
@@ -3,7 +3,7 @@
  */
 #Extends "Modes/ModeBase2.Script.txt"
 
-#Const MB_MM_Version			"2017-11-21"
+#Const MB_MM_Version			"2018-02-15"
 #Const MB_MM_ScriptName	"Modes/ModeMatchmaking2.Script.txt"
 
 // ---------------------------------- //
@@ -873,6 +873,28 @@ Void MM_Private_EnablePenalty(Boolean _Enabled) {
  */
 Boolean MM_Private_PenaltyIsEnabled() {
 	return MMMatch::PenaltyEnabled();
+}
+
+// ---------------------------------- //
+/** Enable or disable the match server
+ *	reconnect for the players
+ *
+ *	@param	_Enabled									True to enable the match reconnect
+ *																		False to disable
+ */
+Void MM_Private_EnableMatchReconnect(Boolean _Enabled) {
+	MMLobby::EnableMatchReconnect(_Enabled);
+}
+
+// ---------------------------------- //
+/** Check if the match server reconnect
+ *	is enabled
+ *
+ *	@return														True if the match reconnect is enabled
+ *																		False if the match reconnect is disabled
+ */
+Boolean MM_Private_MatchReconnectIsEnabled() {
+	return MMLobby::MatchReconnectEnabled();
 }
 
 // ---------------------------------- //

--- a/Common/Scripts/Modes/ShootMania/Base/ModeShootmania.Script.txt
+++ b/Common/Scripts/Modes/ShootMania/Base/ModeShootmania.Script.txt
@@ -3,7 +3,7 @@
  */
 #Extends "Modes/ShootMania/Base/ModeMatchmaking2.Script.txt"
 
-#Const MS_Version			"2017-07-11"
+#Const MS_Version			"2018-02-15"
 #Const MS_ScriptName	"Modes/ShootMania/ModeShootmania.Script.txt"
 
 /*
@@ -1349,4 +1349,26 @@ Void MM_EnablePenalty(Boolean _Enabled) {
  */
 Boolean MM_PenaltyIsEnabled() {
 	return MM_Private_PenaltyIsEnabled();
+}
+
+// ---------------------------------- //
+/** Enable or disable the match server
+ *	reconnect for the players
+ *
+ *	@param	_Enabled									True to enable the match reconnect
+ *																		False to disable
+ */
+Void MM_EnableMatchReconnect(Boolean _Enabled) {
+	MM_Private_EnableMatchReconnect(_Enabled);
+}
+
+// ---------------------------------- //
+/** Check if the match server reconnect
+ *	is enabled
+ *
+ *	@return														True if the match reconnect is enabled
+ *																		False if the match reconnect is disabled
+ */
+Boolean MM_MatchReconnectIsEnabled() {
+	return MM_Private_MatchReconnectIsEnabled();
 }

--- a/Common/Scripts/Modes/TrackMania/Base/ModeTrackmania.Script.txt
+++ b/Common/Scripts/Modes/TrackMania/Base/ModeTrackmania.Script.txt
@@ -3,7 +3,7 @@
  */
 #Extends "Modes/TrackMania/Base/ModeMatchmaking2.Script.txt"
 
-#Const MT_Version			"2017-07-11"
+#Const MT_Version			"2018-02-15"
 #Const MT_ScriptName	"Modes/TrackMania/ModeTrackmania.Script.txt"
 
 /*
@@ -1366,4 +1366,26 @@ Void MM_EnablePenalty(Boolean _Enabled) {
  */
 Boolean MM_PenaltyIsEnabled() {
 	return MM_Private_PenaltyIsEnabled();
+}
+
+// ---------------------------------- //
+/** Enable or disable the match server
+ *	reconnect for the players
+ *
+ *	@param	_Enabled									True to enable the match reconnect
+ *																		False to disable
+ */
+Void MM_EnableMatchReconnect(Boolean _Enabled) {
+	MM_Private_EnableMatchReconnect(_Enabled);
+}
+
+// ---------------------------------- //
+/** Check if the match server reconnect
+ *	is enabled
+ *
+ *	@return														True if the match reconnect is enabled
+ *																		False if the match reconnect is disabled
+ */
+Boolean MM_MatchReconnectIsEnabled() {
+	return MM_Private_MatchReconnectIsEnabled();
 }


### PR DESCRIPTION
Useful, when game mode creator doesn't want players to reconnect to the matches they've left (for example a battle royale match).

Match reconnection is causing major problems in HG matchmaking, where eliminated players are supposed to be transferred back from ongoing match back to the lobby, allowing them to participate in a new match, while the remaining players in abandoned server can finish their game. Currently, the player is transferred back to the match, in which they can no longer participate, instead of staying in the lobby.

My fix contains similar functions and methods as your other "settings", cutting off `ReconnectToServer()` method when disabled.