### PR TITLE
Fix for timer showing wrong time on respawn

### DIFF
--- a/Makers/base/Scripts/Libs/TrackMania/Ingame/UI/UI.Script.txt
+++ b/Makers/base/Scripts/Libs/TrackMania/Ingame/UI/UI.Script.txt
@@ -438,7 +438,7 @@ declare Integer          G_BestLapTime;
 Text GetRaceTime()
 {
 	declare Integer TimeInt = GameTime - GUIPlayer.RaceStartTime;
-	if(TimeInt < 0) TimeInt = 0;
+	if(TimeInt < 0 || GUIPlayer.RaceStartTime == 0) TimeInt = 0;
 	declare Text TimeText = TL::TimeToText(TimeInt, True);
 	return TimeText;
 }


### PR DESCRIPTION
A bug caused due to RaceStartTime having value 0 for a split second on respawn.