### PR TITLE
Joust - Fix crashes when trying to respawn a player with 0 armor

### DIFF
--- a/Titles/SMStormJoust@nadeolabs/Scripts/Modes/ShootMania/Joust/JoustPro.Script.txt
+++ b/Titles/SMStormJoust@nadeolabs/Scripts/Modes/ShootMania/Joust/JoustPro.Script.txt
@@ -532,7 +532,12 @@ foreach (Event in PendingEvents) {
 						}
 						CurrGoalsSide[I] = -1;
 						AGoalHaveBeenCaptured = True;
-						JoustRespawnPlayer(Event.Victim, Now+3000, Event.Victim.Armor - 100);
+
+						declare Integer PlayerArmor = Event.Victim.Armor - 100;
+
+						if(PlayerArmor > 0) {
+						    JoustRespawnPlayer(Event.Victim, Now+3000, PlayerArmor);
+						}
 					}
 				}
 				SetScoreHeader();
@@ -559,7 +564,12 @@ foreach (Event in PendingEvents) {
 					}
 					CurrGoalsSide[I] = -1;
 					AGoalHaveBeenCaptured = True;
-					JoustRespawnPlayer(Event.Player, Now+3000, Event.Player.Armor - 100);
+
+					declare Integer PlayerArmor = Event.Player.Armor - 100;
+
+					if(PlayerArmor > 0) {
+					    JoustRespawnPlayer(Event.Player, Now+3000, PlayerArmor);
+					}
 				}
 			}
 			SetScoreHeader();


### PR DESCRIPTION
Resolves #7 - Fixes the crash occured when a player has 1 armor and gets eliminated from offzone or presses backspace.