### PR TITLE
Change UI chrono horizontal align to right

### DIFF
--- a/Makers/base/Scripts/Libs/TrackMania/Ingame/UI/UI.Script.txt
+++ b/Makers/base/Scripts/Libs/TrackMania/Ingame/UI/UI.Script.txt
@@ -404,7 +404,7 @@ Text Private_GetMLRace(Real _Scale, Vec2 _PosRatio, Real _SpecialScale, Vec2 _Cl
 		</frame>
 
 		<frame id="Frame_Chrono" pos="0 -76.5" hidden="1">
-			<label id="Label_Chrono" halign="center" valign="center" z-index="1" pos="0 0" size="50" textsize="2" scale="4" text="0" textfont="{{{G_FontChrono}}}"/>
+			<label id="Label_Chrono" halign="right" valign="center" z-index="1" pos="19.25 0" size="50" textsize="2" scale="4" text="0" textfont="{{{G_FontChrono}}}"/>
 			<quad  halign="center" valign="center" z-index="1" pos="29.1 -4" size="15.2 5" style="Bgs1" substyle="BgDialogBlur" opacity="0.1" bluramount="0.1"/>
 			<quad  halign="center" valign="center" z-index="1" pos="29.1 -4" size="15.2 5" bgcolor="888" opacity="0.3"/>
 			<label halign="center" valign="center" z-index="1" pos="29.3 -3.7" size="15" textsize="2" scale="1" text="RACE TIME" textfont="{{{G_FontMain}}}"/>


### PR DESCRIPTION
To avoid overlap with RACE TIME, if the chrono goes over 10 minutes, I changed the alignment to a good value which additionally doesn't change the chrono position when time is below 10 minutes.

Previous
![image](https://user-images.githubusercontent.com/3035217/79293000-d2050e00-7ed2-11ea-8611-601eff2175f8.png)

Now
![image](https://user-images.githubusercontent.com/3035217/79293013-da5d4900-7ed2-11ea-9c27-482f22b47ddd.png)
